### PR TITLE
ESA-742 Fixed issue relating to Contacts with no email address

### DIFF
--- a/force-app/main/default/classes/ExternalCommitteeAlert.cls
+++ b/force-app/main/default/classes/ExternalCommitteeAlert.cls
@@ -67,6 +67,6 @@ public with sharing class ExternalCommitteeAlert {
     }
 
     public static List<Contact> getRelatedContacts(Id accountId){
-        return [SELECT Id FROM Contact WHERE AccountId = :accountId];
+        return [SELECT Id, Email FROM Contact WHERE AccountId = :accountId AND Email != NULL];
     }
 }


### PR DESCRIPTION
Emails would not send if even one of the related Contact records did not have an email address.