### PR TITLE
SA-104 support biologic excluded plans

### DIFF
--- a/force-app/main/default/objects/Drug_Template__c/fields/Excluded_Plans__c.field-meta.xml
+++ b/force-app/main/default/objects/Drug_Template__c/fields/Excluded_Plans__c.field-meta.xml
@@ -36,9 +36,19 @@
                 <label>G</label>
             </value>
             <value>
+                <fullName>GE</fullName>
+                <default>false</default>
+                <label>GE</label>
+            </value>
+            <value>
                 <fullName>MM</fullName>
                 <default>false</default>
                 <label>MM</label>
+            </value>
+            <value>
+                <fullName>P</fullName>
+                <default>false</default>
+                <label>P</label>
             </value>
             <value>
                 <fullName>S</fullName>


### PR DESCRIPTION
Changes to picklist for excluded plans custom object as part of drug templates, to support use of correct excluded plans when generating payloads for biologic medications.

Details in ticket SA-104
Object Manager > Drug Template > Fields and Relationships > Excluded Plans (Unlocked) Picklist options > New > GE, P > Reorder to alphabetize.  