### PR TITLE
Updated Permissionset, Accountjson

### DIFF
--- a/data/comm-accounts.json
+++ b/data/comm-accounts.json
@@ -5,7 +5,6 @@
                 "type": "Account",
                 "referenceId": "AccountRef1"
             },
-            "RecordTypeId": "0121f000000jXvtAAE",
             "Name": "IBD DBAAC"
         },
         {
@@ -13,7 +12,6 @@
                 "type": "Account",
                 "referenceId": "AccountRef2"
             },
-            "RecordTypeId": "0121f000000jXvtAAE",
             "Name": "MS DBAAC"
         },
         {
@@ -21,7 +19,6 @@
                 "type": "Account",
                 "referenceId": "AccountRef3"
             },
-            "RecordTypeId": "0121f000000jXvtAAE",
             "Name": "HIBC"
         },
         {
@@ -29,7 +26,6 @@
                 "type": "Account",
                 "referenceId": "AccountRef4"
             },
-            "RecordTypeId": "0121f000000jXvtAAE",
             "Name": "Service BC"
         }
     ]

--- a/dev-app-post/main/default/profiles/Admin.profile-meta.xml
+++ b/dev-app-post/main/default/profiles/Admin.profile-meta.xml
@@ -518,6 +518,11 @@
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <recordTypeVisibilities>
+        <default>true</default>
+        <recordType>Account.Business_Account</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
         <default>false</default>
         <recordType>Account.DEC</recordType>
         <visible>true</visible>
@@ -528,7 +533,7 @@
         <visible>true</visible>
     </recordTypeVisibilities>
     <recordTypeVisibilities>
-        <default>true</default>
+        <default>false</default>
         <personAccountDefault>true</personAccountDefault>
         <recordType>PersonAccount.Patient</recordType>
         <visible>true</visible>

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -73,7 +73,7 @@ dx force:data:bulk:upsert -u $alias -s Drug__c -f data/drugs.csv -i Drug_Code__c
 dx force:data:bulk:upsert -u $alias -s Account -f data/accounts.csv -i Id -w 5 
 dx force:data:bulk:upsert -u $alias -s Account -f data/decs.csv -i Id -w 5 
 dx force:data:bulk:upsert -u $alias -s Case -f data/cases.csv -i Id -w 5
-# dx force:data:tree:import -u $alias -p data/comm-plan.json
+dx force:data:tree:import -u $alias -p data/comm-plan.json
 dx force:apex:execute -u $alias -f scripts/apex/scratchorg-add-comm-users.apex
 dx force:apex:execute -u $alias -f scripts/apex/scratchorg-assign-cases-to-ecs.apex
 dx force:apex:execute -u $alias -f scripts/apex/scratchorg-assign-cases-to-queue.apex

--- a/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
@@ -1399,7 +1399,6 @@
         <enabled>true</enabled>
     </pageAccesses>
     <recordTypeVisibilities>
-        <default>true</default>
         <recordType>Account.DEC</recordType>
         <visible>true</visible>
     </recordTypeVisibilities>

--- a/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
@@ -1399,6 +1399,11 @@
         <enabled>true</enabled>
     </pageAccesses>
     <recordTypeVisibilities>
+        <default>true</default>
+        <recordType>Account.Business_Account</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
         <recordType>Account.DEC</recordType>
         <visible>true</visible>
     </recordTypeVisibilities>

--- a/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
@@ -1400,10 +1400,6 @@
     </pageAccesses>
     <recordTypeVisibilities>
         <default>true</default>
-        <recordType>Account.Business_Account</recordType>
-        <visible>true</visible>
-    </recordTypeVisibilities>
-    <recordTypeVisibilities>
         <recordType>Account.DEC</recordType>
         <visible>true</visible>
     </recordTypeVisibilities>


### PR DESCRIPTION
Removed the RecordTypeID from Account.Json file
Updated Account.Business_Account recordtype as default RecordType in the Permission Set

According to the salesforce suggestion :

[profile - Record type missing for : Account; CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY : Minimum Access - Salesforce - Salesforce Stack Exchange](https://salesforce.stackexchange.com/questions/380171/record-type-missing-for-account-cannot-insert-update-activate-entity-minimu)

we need to update the System admin profile so that the default  Record type for the Account should be Business Account.

If we update this then the command "dx force:data:tree:import -u $alias -p data/comm-plan.json" won't have any issues.
