### PR TITLE
Updating the Sfdx release version

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,8 +8,8 @@
       "path": "force-app",
       "default": true,
       "package": "Special Authority App",
-      "versionName": "Version 15",
-      "versionNumber": "11.0.15.NEXT"
+      "versionName": "Version 17",
+      "versionNumber": "11.0.17.NEXT"
     },
     {
       "path": "dev-app-post",


### PR DESCRIPTION
Updating the version number from Version 15 to Version 17 to match the release branch or to be in sync with the release branch.
This is for avoiding future confusion.
Currently, for the PROD deployment, we have to create the release branch version number 17 but our version will be on 16. So, to avoid this confusion I have updated the version number to Version 17.
From the next release:
The release branch and the version number in sfdx-project.json will be the same or in sync