### PR TITLE
BCMOHAD-16521 || Update the related list to "Account" from "Contact"

### DIFF
--- a/force-app/main/default/flexipages/SA_Case_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/SA_Case_Record_Page.flexipage-meta.xml
@@ -143,7 +143,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>parentFieldApiName</name>
-                    <value>Case.ContactId</value>
+                    <value>Case.AccountId</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>relatedListApiName</name>
@@ -159,7 +159,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>showActionBar</name>
-                    <value>false</value>
+                    <value>true</value>
                 </componentInstanceProperties>
                 <componentName>force:relatedListSingleContainer</componentName>
                 <identifier>force_relatedListSingleContainer4</identifier>


### PR DESCRIPTION
Deployment Tracker:
Updated the Case Flexi Page in the related lists. Changed the related lists from Contacts to Accounts as per Salesforce's suggestion to avoid future problems.

Files changed:
force-app/main/default/flexipages/SA_Case_Record_Page.flexipage-meta.xml
