### PR TITLE
BCMOHAD-16884 || Updating the EMPI Timeout to 60 seconds

### DIFF
--- a/force-app/main/default/classes/EmpiIntegration.cls
+++ b/force-app/main/default/classes/EmpiIntegration.cls
@@ -96,6 +96,7 @@ public with sharing class EmpiIntegration {
         
         Empi.QUPA_AR101102_Port stub = new Empi.QUPA_AR101102_Port();
         stub.endpoint_x = 'callout:empi/HCIM.Services.Secured/Synchronous/QUPA_AR101102.svc'; // TEST
+        stub.timeout_x = 60000;
         
         Patient p = new Patient();
         p.phn = phn;

--- a/force-app/main/default/classes/ODRIntegration.cls
+++ b/force-app/main/default/classes/ODRIntegration.cls
@@ -611,6 +611,7 @@ public static PrescriptionHistoryResponse fetchPrescriptionHistoryWithSearchKey(
         req.setHeader('Content-Type','application/json');
         req.setEndpoint(uri);
         req.setMethod(method);
+        req.setTimeout(60000);
         
         System.debug(methodBody);
         


### PR DESCRIPTION
Deployment Tracker:

Updating the EMPIIntegration class with a timeout.
Updating the ODRIntegrationclass with a timeout.

Class:
force-app/main/default/classes/EmpiIntegration.cls
force-app/main/default/classes/ODRIntegration.cls