### PR TITLE
BCMOHAM-13541 || Added prescriberResult and patientResult

### DIFF
--- a/force-app/main/default/lwc/odrLookup/odrLookup.js
+++ b/force-app/main/default/lwc/odrLookup/odrLookup.js
@@ -50,11 +50,11 @@ export default class OdrLookup extends LightningElement {
     }
 
     isPrescriberValid() { // Added this.prescriberResult as we are trying to access prescriberResult.overrideReason without checking if the prescriberResult is undefined or not
-        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.hasOverride(this.prescriberResult && this.prescriberResult.overrideReason);
+        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.hasOverride(this.prescriberResult) || this.hasOverride(this.prescriberResult.overrideReason);
     }
 
     isPatientValid() { // Added this.patientResult as we are trying to access patientResult.overrideReason without checking if the patientResult is undefined or not
-        return !this.showPatient || (this.patient && this.patientResult.verified) || this.hasOverride(this.patientResult && this.patientResult.overrideReason);
+        return !this.showPatient || (this.patient && this.patientResult.verified) || this.hasOverride(this.patientResult) || this.hasOverride(this.patientResult.overrideReason);
     }
 
     isSubmitterValid() {

--- a/force-app/main/default/lwc/odrLookup/odrLookup.js
+++ b/force-app/main/default/lwc/odrLookup/odrLookup.js
@@ -50,11 +50,11 @@ export default class OdrLookup extends LightningElement {
     }
 
     isPrescriberValid() { // Added this.prescriberResult as we are trying to access prescriberResult.overrideReason without checking if the prescriberResult is undefined or not
-        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.hasOverride(this.prescriberResult) || this.hasOverride(this.prescriberResult.overrideReason);
+        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.prescriberResult?.overrideReason;
     }
 
     isPatientValid() { // Added this.patientResult as we are trying to access patientResult.overrideReason without checking if the patientResult is undefined or not
-        return !this.showPatient || (this.patient && this.patientResult.verified) || this.hasOverride(this.patientResult) || this.hasOverride(this.patientResult.overrideReason);
+        return !this.showPatient || (this.patient && this.patientResult.verified) || this.patientResult?.overrideReason;
     }
 
     isSubmitterValid() {

--- a/force-app/main/default/lwc/odrLookup/odrLookup.js
+++ b/force-app/main/default/lwc/odrLookup/odrLookup.js
@@ -49,12 +49,12 @@ export default class OdrLookup extends LightningElement {
         }
     }
 
-    isPrescriberValid() {
-        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.hasOverride(this.prescriberResult.overrideReason);
+    isPrescriberValid() { // Added this.prescriberResult as we are trying to access prescriberResult.overrideReason without checking if the prescriberResult is undefined or not
+        return !this.showPrescriber || (this.prescriber && this.prescriberResult.verified) || this.hasOverride(this.prescriberResult && this.prescriberResult.overrideReason);
     }
 
-    isPatientValid() {
-        return !this.showPatient || (this.patient && this.patientResult.verified) || this.hasOverride(this.patientResult.overrideReason);
+    isPatientValid() { // Added this.patientResult as we are trying to access patientResult.overrideReason without checking if the patientResult is undefined or not
+        return !this.showPatient || (this.patient && this.patientResult.verified) || this.hasOverride(this.patientResult && this.patientResult.overrideReason);
     }
 
     isSubmitterValid() {


### PR DESCRIPTION
Deployment Tracker:
Added this.prescriberResult and this.patientResult in the "force-app/main/default/lwc/odrLookup/odrLookup.js"

Reason:
It was looping when we don't give any details in the create SA request and click on the Next button instead of giving an error message