### PR TITLE
BCMOHAM-14715 || Adding OmniStudio functionality

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Deploy source
       run: |
-        sf project deploy start -d dev-app-pre -o ciorg --checkonly --ignorewarnings
-        sf project deploy start -d force-app -o ciorg
+        sf project deploy start -d dev-app-pre -o ciorg --ignore-warnings
+        sf project deploy start -d force-app -o ciorg 
         sf project deploy start -d force-app/main/default/objects -o ciorg -w 15
         sf project deploy start -d force-app/main/default/queues -o ciorg -w 15
         sf project deploy start -d dev-app-post -o ciorg -c

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Deploy source
       run: |
-        sf project deploy start -d dev-app-pre -o ciorg
+        sf project deploy start -d dev-app-pre -o ciorg --checkonly --ignorewarnings
         sf project deploy start -d force-app -o ciorg
         sf project deploy start -d force-app/main/default/objects -o ciorg -w 15
         sf project deploy start -d force-app/main/default/queues -o ciorg -w 15

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,7 +2,7 @@
   "orgName": "Special Authority Scratch Org",
   "edition": "Developer",
   "description": "This org is created for Spring'23 org ",
-  "features": ["PersonAccounts", "LightningServiceConsole", "ServiceCloud","Communities","Sites","HealthCloudAddOn","ContactsToMultipleAccounts"],
+  "features": ["PersonAccounts", "LightningServiceConsole", "ServiceCloud","Communities","Sites","HealthCloudAddOn","ContactsToMultipleAccounts","OmniStudioDesigner","OmniStudioRuntime"],
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true


### PR DESCRIPTION
- Adding OmniStudio capabilities to scratch org definition file
Please treat it as a workaround to enable OmniStudio in scratch orgs. Pending resolution with Salesforce. 
- Adding ignore-warnings flag
It appears to be a known issue since sf project deploy start command does not produce diagnostic info. Please refer to this article: https://github.com/forcedotcom/cli/issues/2561