### PR TITLE
BCMOHAD-18955 || Fixing QA Deployment Errors

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -123,3 +123,4 @@ Business_Account.recordType
 
 # Added to ignore this file deployment.
 force-app/main/default/globalValueSets/*
+force-app/main/default/pathAssistants/HIBC_Status.pathAssistant-meta.xml

--- a/force-app/main/default/profiles/Service Account Profile.profile-meta.xml
+++ b/force-app/main/default/profiles/Service Account Profile.profile-meta.xml
@@ -572,10 +572,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>Packaging2PromoteVersion</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>PrivacyDataAccess</name>
     </userPermissions>
     <userPermissions>

--- a/force-app/main/default/reportTypes/Cases_with_Case_Comments.reportType-meta.xml
+++ b/force-app/main/default/reportTypes/Cases_with_Case_Comments.reportType-meta.xml
@@ -182,11 +182,6 @@
         </columns>
         <columns>
             <checkedByDefault>false</checkedByDefault>
-            <field>AssetWarranty</field>
-            <table>Case</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
             <field>ServiceContract</field>
             <table>Case</table>
         </columns>

--- a/force-app/main/default/reportTypes/Cases_with_Case_Comments_for_Account.reportType-meta.xml
+++ b/force-app/main/default/reportTypes/Cases_with_Case_Comments_for_Account.reportType-meta.xml
@@ -256,11 +256,6 @@
         </columns>
         <columns>
             <checkedByDefault>false</checkedByDefault>
-            <field>CleanStatus</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
             <field>AccountSource</field>
             <table>Account</table>
         </columns>

--- a/force-app/main/default/reports/MOHStandardUsers.reportFolder-meta.xml
+++ b/force-app/main/default/reports/MOHStandardUsers.reportFolder-meta.xml
@@ -5,10 +5,5 @@
         <sharedTo>AllInternalUsers</sharedTo>
         <sharedToType>Organization</sharedToType>
     </folderShares>
-    <folderShares>
-        <accessLevel>Manage</accessLevel>
-        <sharedTo>test-ghds7vjcn14o@example.com</sharedTo>
-        <sharedToType>User</sharedToType>
-    </folderShares>
     <name>MOH-Standard Users</name>
 </ReportFolder>


### PR DESCRIPTION
Removing hard coded reference in source code
Removing fields not applicable to the org
Ignoring inactive HIBC_Status path

The unknown user permission issue is related to the PR: https://github.com/bcgov/MoH-SAT/commit/79c9b7f3a28d81ceffabdec9e4690157838a6c3c

It is related to manage package development permission which was recently pulled from Production. Jeff, I am assuming there is no concerns from your side if we remove it since it was empty in the repo by design. 

Removing Packaging2PromoteVersion permission
Package development permission assignment needs to be perfromed as a post deployment step. 