### PR TITLE
BCMOHAD-18354 || Adding HC permission set to build-check

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Assign permission set and set user role
       run: |
           sf force:user:permset:assign -o ciorg -n SA_Administrator
-          sf force:user:permset:assign -u ciorg -n HealthCloudFoundation
+          sf force:user:permset:assign -o ciorg -n HealthCloudFoundation
           sf force:apex:execute -o ciorg -f scripts/apex/scratchorg-set-current-user.apex
         # sfdx force:user:permset:assign -u ciorg -n SA_Administrator
         # sfdx force:apex:execute -u ciorg -f scripts/apex/scratchorg-set-current-user.apex

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Assign permission set and set user role
       run: |
           sf force:user:permset:assign -o ciorg -n SA_Administrator
+          sf force:user:permset:assign -u ciorg -n HealthCloudFoundation
           sf force:apex:execute -o ciorg -f scripts/apex/scratchorg-set-current-user.apex
         # sfdx force:user:permset:assign -u ciorg -n SA_Administrator
         # sfdx force:apex:execute -u ciorg -f scripts/apex/scratchorg-set-current-user.apex


### PR DESCRIPTION
Adding Health Cloud permission set to fix the error "The object "CareProgramEnrollee" can't be updated through a flow" 