### PR TITLE
BCMOHAD-18354 || Default Data.com fields cleanup

### DIFF
--- a/force-app/main/default/reportTypes/Cases_with_Case_Comments_for_Account.reportType-meta.xml
+++ b/force-app/main/default/reportTypes/Cases_with_Case_Comments_for_Account.reportType-meta.xml
@@ -261,37 +261,7 @@
         </columns>
         <columns>
             <checkedByDefault>false</checkedByDefault>
-            <field>DunsNumber</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>Tradestyle</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>NaicsCode</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>NaicsDesc</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>YearStarted</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
             <field>SicDesc</field>
-            <table>Account</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>DandbCompany</field>
             <table>Account</table>
         </columns>
         <columns>
@@ -475,11 +445,6 @@
         <columns>
             <checkedByDefault>false</checkedByDefault>
             <field>LastModifiedBy</field>
-            <table>Account.Cases</table>
-        </columns>
-        <columns>
-            <checkedByDefault>false</checkedByDefault>
-            <field>AssetWarranty</field>
             <table>Account.Cases</table>
         </columns>
         <columns>


### PR DESCRIPTION
Removing default Data.com fields to make the report type deployable. The fields are not being used in Production. 

The list of fields on Account: 
DunsNumber, 
Tradestyle, 
NaicsCode, 
NaicsDesc, 
YearStarted, 
DandbCompany,
AssertWarranty
