### PR TITLE
BCMOHAM-14323 || upgrading OmniStudio package to Spring 24 in scratch org

### DIFF
--- a/.github/workflows/Manual Build Check.yml
+++ b/.github/workflows/Manual Build Check.yml
@@ -9,7 +9,7 @@ jobs:
       SF_DISABLE_SOURCE_MEMBER_POLLING: true
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -31,7 +31,7 @@ jobs:
       # sfdx force:org:create -v devhub -s -f config/project-scratch-def.json -a ciorg -d 1
 
     - name: Installing SF managed packages
-      run: sf package install --package "04t4W000000YWaz" -o ciorg -w 15 --noprompt 
+      run: sf package install --package "04t4W0000038bemQAA" -o ciorg -w 15 --noprompt 
 
     - name: Set deployment user standard security
       run: |

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -8,7 +8,7 @@ jobs:
       SF_DISABLE_SOURCE_MEMBER_POLLING: true
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -30,7 +30,7 @@ jobs:
       # sfdx force:org:create -v devhub -s -f config/project-scratch-def.json -a ciorg -d 1
 
     - name: Installing SF managed packages
-      run: sf package install --package "04t4W000000YWaz" -o ciorg -w 15 --noprompt 
+      run: sf package install --package "04t4W0000038bemQAA" -o ciorg -w 15 --noprompt 
 
     - name: Set deployment user standard security
       run: |


### PR DESCRIPTION
# Description

OmniStudio package was automatically upgraded in Production and lower environments with the new OmniStudio Release. Raising PR to upgrade the OmniStudio package to Spring 2024 in scratch orgs.

Fixes # (issue)
[BCMOHAM-14323](https://proactionca.ent.cgi.com/jira/browse/BCMOHAM-14323)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# List high-level changes as bullet items

Updated YML Files:
Manual Build Check
build-checks