### PR TITLE
BCMOHAD-21498-v1 || Created the new Permission set Group

### DIFF
--- a/force-app/main/default/permissionsetgroups/SA_Operational_Support.permissionsetgroup-meta.xml
+++ b/force-app/main/default/permissionsetgroups/SA_Operational_Support.permissionsetgroup-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSetGroup xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>operational support permission set for SAT</description>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>SA Operational Support</label>
+    <permissionSets>DevHub_Developer</permissionSets>
+    <permissionSets>GitHub_Actions</permissionSets>
+    <permissionSets>SA_Administrator</permissionSets>
+    <status>Updated</status>
+</PermissionSetGroup>

--- a/force-app/main/default/permissionsets/DevHub_Developer.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/DevHub_Developer.permissionset-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>DevHub Developer</label>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>Packaging2</name>
+    </userPermissions>
+</PermissionSet>

--- a/force-app/main/default/permissionsets/GitHub_Actions.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/GitHub_Actions.permissionset-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>GitHub Actions</label>
+</PermissionSet>


### PR DESCRIPTION
# Description

Created the new permission set Group "**SA Operational Support**" and added the permission sets in it

Post Deployment Steps:
Once the deployment is successful please go to **set up** in **Salesforce** and type **Permission Set Groups** in the quick find box and select the "**SA Operational Support**" Permission Set Group and add the following permission sets:

- **Event Monitoring Analytics Admin**
- **Manage Community Users**


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Deployment Tracker

force-app/main/default/permissionsetgroups/SA_Operational_SupportSA_Operational_Support.permissionsetgroup-meta.xml
force-app/main/default/permissionsets/DevHub_Developer.permissionset-meta.xml
force-app/main/default/permissionsets/GitHub_Actions.permissionset-meta.xml
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules