### PR TITLE
BCMOHAD-24466 || Removed the Test Group and added the General_Queue

### DIFF
--- a/force-app/main/default/classes/QueueOwnerSetterTest.cls
+++ b/force-app/main/default/classes/QueueOwnerSetterTest.cls
@@ -3,8 +3,12 @@ public class QueueOwnerSetterTest {
 
     @TestSetup
     static void makeData() {
-        Group testGroup = new Group(Name='TestGroup', DeveloperName='TestGroup', Type='Queue');
-        insert testGroup;
+        
+        Group testGroup = [SELECT Id, Name, DeveloperName, Type FROM GROUP WHERE DeveloperName = 'General_Queue' LIMIT 1];
+        if(testGroup == NULL){
+            testGroup = new Group(Name='General_Queue', DeveloperName='General_Queue', Type='Queue');
+            insert testGroup;
+        }
         
         system.runAs(new User(Id=UserInfo.getUserId())) {    
             insert new QueueSobject[] { 
@@ -20,14 +24,14 @@ public class QueueOwnerSetterTest {
         insert saCase;
 
         List<QueueOwnerSetter.CaseQueue> caseQueues = new List<QueueOwnerSetter.CaseQueue>();
-        caseQueues.add(newCaseQueue(saCase.Id, 'TestGroup'));
+        caseQueues.add(newCaseQueue(saCase.Id, 'General_Queue'));
 
         Test.startTest();
         QueueOwnerSetter.setOwner(caseQueues);
         Test.stopTest();
 
         system.assertEquals(
-            [select Id from Group where DeveloperName = 'TestGroup'].Id,
+            [select Id from Group where DeveloperName = 'General_Queue'].Id,
             [select OwnerId from Case where Id = :saCase.Id].OwnerId
         );
     }


### PR DESCRIPTION
# Description

Removed the Test Group from the test class and added the General_Queue because we have created a validation rule that SAT cases can only be assigned to SAT queues

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Deployment Tracker

force-app/main/default/classes/QueueOwnerSetterTest.cls

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules