### PR TITLE
Revert "BCMOHAM-19482 || adding deployment command to install the IAM package into scratch org"

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Installing SF managed packages
       run: sf package install --package "04t4W0000038bemQAA" -o ciorg -w 15 --noprompt 
 
-    - name: Installing the IAM package 
-      run: sf package install --package "04tJQ0000014BvZYAU" -o ciorg -w 15 --noprompt 
-
     - name: Set deployment user standard security
       run: |
           sf force:user:permsetlicense:assign -u ciorg -n "OmniStudio"


### PR DESCRIPTION
Reverts bcgov/MoH-SAT#1364
It is expected that the IAM package gets installed along with OS managed package upon scratch org creation. There is a package dependency on HealthCloud. It appears that Health Cloud installation key is not valid, so we would need to send a request to Salesforce to get a new package installation link. 
Workaround: Proceed with post deployment steps to create the configuration of the IAM in Production. 