### PR TITLE
Adding the custom Permissions to SA Admin for bypassing the AccountNa…

### DIFF
--- a/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/SA_Administrator.permissionset-meta.xml
@@ -68,6 +68,10 @@
         <enabled>true</enabled>
         <name>Drug_Manager</name>
     </customPermissions>
+    <customPermissions>
+        <enabled>true</enabled>
+        <name>SA_Team_Lead</name>
+    </customPermissions>
     <externalCredentialPrincipalAccesses>
         <enabled>true</enabled>
         <externalCredentialPrincipal>LRA_OAuth_TokenRequest-Client Credentials</externalCredentialPrincipal>


### PR DESCRIPTION

# Description
 
SA Team Lead is an existing custom permission that is already used to bypass the Account Name change validation rule.
Adding the custom permission to the SA Admin Permission  which is associated with SA _Administrator Persona only Megan, Rick and Cora has this permission set.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# List high-level changes as bullet items

Below are some examples

- [ ] Changed field permissions
- [ ] changed field data-type

# Deployment Tracker

List all the metadata that is pushed in this commit/PR. Full URL should be fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules